### PR TITLE
feat(gui): Migrate from iced 0.13.1 to iced 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed - 2026-01-10 (Iced 0.14.0 Migration)
+
+#### GUI Framework Upgrade: Iced 0.13.1 to 0.14.0
+- **Major Version Upgrade**: Complete migration from iced 0.13.1 to iced 0.14.0 with 82+ breaking API changes resolved
+- **Key Features**: Reactive rendering improvements, time-travel debugging, and enhanced API design
+
+#### Breaking API Changes Fixed
+- **Space Widget API**: Replaced deprecated `Space::with_width/with_height` with `Space::new().width/height()`
+- **Application API**: Migrated from `iced::application(title, update, view)` to `iced::application(boot_fn, update, view).title()`
+- **Horizontal/Vertical Space**: Removed deprecated helpers, now using `Space::new().width(Length::Fill)` pattern
+- **Rule Widget**: Changed `horizontal_rule(height)` to `rule::horizontal(height)`
+- **Checkbox API**: Updated from `checkbox(label, value)` to `checkbox(value).label(label)` builder pattern
+- **Scrollable IDs**: Migrated from `scrollable::Id` to `iced::widget::Id`
+- **Scrollable Operations**: Changed `scrollable::snap_to` to `operation::snap_to`
+- **Text Input Status**: Updated `text_input::Status::Focused` to struct variant with `is_hovered` field
+- **Style Structs**: Added required `snap: bool` field to `button::Style` and `container::Style`
+- **Pixels Type**: Updated return types from `u16` to `f32` for Pixels trait bounds
+
+#### Files Modified (19 total)
+- `Cargo.toml` - Version bump to iced 0.14.0
+- `crates/rustirc-gui/src/app.rs` - Application API and rule widget
+- `crates/rustirc-gui/src/dialogs.rs` - Space, checkbox, and max_width APIs
+- `crates/rustirc-gui/src/material_demo.rs` - Application boot function
+- `crates/rustirc-gui/src/widgets/message_view.rs` - Scrollable ID and operations
+- `crates/rustirc-gui/src/widgets/user_list.rs` - Space widget
+- `crates/rustirc-gui/src/widgets/tab_bar.rs` - Space widget
+- `crates/rustirc-gui/src/widgets/status_bar.rs` - Space widget
+- `crates/rustirc-gui/src/widgets/server_tree.rs` - Space widget
+- `crates/rustirc-gui/src/widgets/input_area.rs` - Space widget
+- `crates/rustirc-gui/src/components/atoms/button.rs` - button::Style snap field
+- `crates/rustirc-gui/src/components/atoms/input.rs` - text_input::Status pattern
+- `crates/rustirc-gui/src/components/molecules/message_bubble.rs` - container::Style snap field
+- `crates/rustirc-gui/src/components/molecules/search_bar.rs` - text_input::Status pattern
+- `crates/rustirc-gui/src/components/organisms/responsive_layout.rs` - Space widget and Pixels type
+- `crates/rustirc-gui/src/components/organisms/rich_text_editor.rs` - text_input::Status patterns
+
+#### Quality Assurance
+- **Build Status**: Zero compilation errors
+- **Clippy**: Zero warnings with -D warnings flag
+- **Tests**: All 131 tests passing (unit + doctests)
+- **Compatibility**: Full backward compatibility with existing GUI functionality
+
 ### Added - 2025-08-26 (Material Design 3 Integration + Dependency Updates)
 
 #### Material Design 3 Branch Integration Complete (2025-08-26 11:56 PM EDT)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,23 +19,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.16",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,9 +71,18 @@ dependencies = [
  "log",
  "ndk",
  "ndk-context",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "android-build"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cac4c64175d504608cf239756339c07f6384a476f97f20a7043f92920b0b8fd"
+dependencies = [
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -171,15 +163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,11 +182,11 @@ checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "ash"
-version = "0.37.3+1.3.251"
+version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e9c3835d686b0a6084ab4234fcd1b07dbf6e4767dce60874b12356a25ecd4a"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
- "libloading 0.7.4",
+ "libloading",
 ]
 
 [[package]]
@@ -242,17 +225,6 @@ dependencies = [
  "futures-lite",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "async-fs"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
 ]
 
 [[package]]
@@ -421,6 +393,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,7 +484,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2 0.6.3",
 ]
 
 [[package]]
@@ -534,12 +524,6 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-
-[[package]]
-name = "by_address"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -642,12 +626,6 @@ checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -701,7 +679,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading 0.8.8",
+ "libloading",
 ]
 
 [[package]]
@@ -759,9 +737,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7f4aaa047ba3c3630b080bb9860894732ff23e2aee290a418909aa6d5df38f"
 dependencies = [
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -794,12 +772,13 @@ dependencies = [
 
 [[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
+ "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -807,37 +786,6 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "com"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e17887fd17353b65b1b2ef1c526c83e26cd72e74f598a8dc1bee13a48f3d9f6"
-dependencies = [
- "com_macros",
-]
-
-[[package]]
-name = "com_macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d375883580a668c7481ea6631fc1a8863e33cc335bf56bfad8d7e6d4b04b13a5"
-dependencies = [
- "com_macros_support",
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "com_macros_support"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad899a1087a9296d5644792d7cb72b8e34c1bec8e7d4fbc002230169a6e8710c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "combine"
@@ -956,22 +904,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmic-text"
-version = "0.12.1"
+name = "core_maths"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fd57d82eb4bfe7ffa9b1cec0c05e2fd378155b47f255a67983cb4afe0e80c2"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "cosmic-text"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173852283a9a57a3cbe365d86e74dc428a09c50421477d5ad6fe9d9509e37737"
 dependencies = [
  "bitflags 2.10.0",
  "fontdb",
+ "harfrust",
+ "linebender_resource_handle",
  "log",
  "rangemap",
- "rayon",
  "rustc-hash 1.1.0",
- "rustybuzz",
  "self_cell",
+ "skrifa",
+ "smol_str",
  "swash",
  "sys-locale",
- "ttf-parser 0.21.1",
  "unicode-bidi",
  "unicode-linebreak",
  "unicode-script",
@@ -985,15 +943,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1067,7 +1016,7 @@ dependencies = [
  "derive_more",
  "document-features",
  "mio",
- "parking_lot 0.12.4",
+ "parking_lot",
  "rustix 1.0.8",
  "signal-hook",
  "signal-hook-mio",
@@ -1088,6 +1037,19 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "cryoglyph"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc795bdbccdbd461736fb163930a009da6597b226d6f6fce33e7a8eb6ec519"
+dependencies = [
+ "cosmic-text",
+ "etagere",
+ "lru",
+ "rustc-hash 2.1.1",
+ "wgpu",
+]
 
 [[package]]
 name = "crypto-common"
@@ -1120,33 +1082,6 @@ name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
-
-[[package]]
-name = "d3d12"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3d747f100290a1ca24b752186f61f6637e1deffe3bf6320de6fcb29510a307"
-dependencies = [
- "bitflags 2.10.0",
- "libloading 0.8.8",
- "winapi",
-]
-
-[[package]]
-name = "dark-light"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a76fa97167fa740dcdbfe18e8895601e1bc36525f09b044e00916e717c03a3c"
-dependencies = [
- "dconf_rs",
- "detect-desktop-environment",
- "dirs",
- "objc",
- "rust-ini",
- "web-sys",
- "winreg",
- "zbus",
-]
 
 [[package]]
 name = "darling"
@@ -1182,12 +1117,6 @@ dependencies = [
  "quote",
  "syn 2.0.106",
 ]
-
-[[package]]
-name = "dconf_rs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7046468a81e6a002061c01e6a7c83139daf91b11c30e66795b13217c2d885c8b"
 
 [[package]]
 name = "deltae"
@@ -1226,12 +1155,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "detect-desktop-environment"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d8ad60dd5b13a4ee6bd8fa2d5d88965c597c67bce32b5fc49c94f55cb50810"
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,30 +1171,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+]
 
 [[package]]
 name = "dlib"
@@ -1279,14 +1192,8 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading 0.8.8",
+ "libloading",
 ]
-
-[[package]]
-name = "dlv-list"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "document-features"
@@ -1308,45 +1215,6 @@ name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
-
-[[package]]
-name = "drm"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98888c4bbd601524c11a7ed63f814b8825f420514f78e96f752c437ae9cbb5d1"
-dependencies = [
- "bitflags 2.10.0",
- "bytemuck",
- "drm-ffi",
- "drm-fourcc",
- "rustix 0.38.44",
-]
-
-[[package]]
-name = "drm-ffi"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c98727e48b7ccb4f4aea8cfe881e5b07f702d17b7875991881b41af7278d53"
-dependencies = [
- "drm-sys",
- "rustix 0.38.44",
-]
-
-[[package]]
-name = "drm-fourcc"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
-
-[[package]]
-name = "drm-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd39dde40b6e196c2e8763f23d119ddb1a8714534bf7d77fa97a65b0feda3986"
-dependencies = [
- "libc",
- "linux-raw-sys 0.6.5",
-]
 
 [[package]]
 name = "dunce"
@@ -1466,25 +1334,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fast-srgb8"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
 
 [[package]]
 name = "filedescriptor"
@@ -1510,20 +1363,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flate2"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1533,9 +1382,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.7.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3971f9a5ca983419cdc386941ba3b9e1feba01a0ab888adf78739feb2798492"
+checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
 dependencies = [
  "bytemuck",
 ]
@@ -1551,16 +1400,16 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.16.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
 dependencies = [
  "fontconfig-parser",
  "log",
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser 0.20.0",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -1767,9 +1616,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "glow"
-version = "0.13.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd348e04c43b32574f2de31c8bb397d96c9fcfa1371bd4ca6d8bdc464ab121b1"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
 dependencies = [
  "js-sys",
  "slotmap",
@@ -1779,9 +1628,9 @@ dependencies = [
 
 [[package]]
 name = "glutin_wgl_sys"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8098adac955faa2d31079b65dc48841251f69efd3ac25477903fc424362ead"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
 dependencies = [
  "gl_generator",
 ]
@@ -1807,33 +1656,32 @@ dependencies = [
 
 [[package]]
 name = "gpu-allocator"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f56f6318968d03c18e1bcf4857ff88c61157e9da8e47c5f29055d60e1228884"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
 dependencies = [
  "log",
  "presser",
  "thiserror 1.0.69",
- "winapi",
- "windows",
+ "windows 0.58.0",
 ]
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.2.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
 dependencies = [
  "bitflags 2.10.0",
  "gpu-descriptor-types",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "gpu-descriptor-types"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
  "bitflags 2.10.0",
 ]
@@ -1856,25 +1704,20 @@ checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
+name = "harfrust"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "92c020db12c71d8a12a3fe7607873cade3a01a6287e29d540c8723276221b9d8"
 dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.12",
- "allocator-api2",
+ "bitflags 2.10.0",
+ "bytemuck",
+ "core_maths",
+ "read-fonts",
+ "smallvec",
 ]
 
 [[package]]
@@ -1882,6 +1725,9 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1891,22 +1737,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
-]
-
-[[package]]
-name = "hassle-rs"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
-dependencies = [
- "bitflags 2.10.0",
- "com",
- "libc",
- "libloading 0.8.8",
- "thiserror 1.0.69",
- "widestring",
- "winapi",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1959,43 +1790,85 @@ dependencies = [
 
 [[package]]
 name = "iced"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88acfabc84ec077eaf9ede3457ffa3a104626d79022a9bf7f296093b1d60c73f"
+checksum = "000e01026c93ba643f8357a3db3ada0e6555265a377f6f9291c472f6dd701fb3"
 dependencies = [
  "iced_core",
+ "iced_debug",
+ "iced_devtools",
  "iced_futures",
  "iced_renderer",
+ "iced_runtime",
  "iced_widget",
  "iced_winit",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "iced_beacon"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02a48f970444257a5e8b19def673f14f0d79c159fa851055e2a861683c3f8845"
+dependencies = [
+ "bincode",
+ "futures",
+ "iced_core",
+ "log",
+ "semver",
+ "serde",
+ "thiserror 2.0.17",
+ "tokio",
 ]
 
 [[package]]
 name = "iced_core"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0013a238275494641bf8f1732a23a808196540dc67b22ff97099c044ae4c8a1c"
+checksum = "91ab1937d699403e7e69252ae743a902bcee9f4ab2052cc4c9a46fcf34729d85"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
- "dark-light",
  "glam",
+ "lilt",
  "log",
  "num-traits",
- "once_cell",
- "palette",
  "rustc-hash 2.1.1",
+ "serde",
  "smol_str",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "web-time",
 ]
 
 [[package]]
-name = "iced_futures"
-version = "0.13.2"
+name = "iced_debug"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c04a6745ba2e80f32cf01e034fd00d853aa4f4cd8b91888099cb7aaee0d5d7c"
+checksum = "25035ab0215a620e53f4103e36fc4e59a1fb2817e4bfc38a30ad27b4202ea0be"
+dependencies = [
+ "iced_beacon",
+ "iced_core",
+ "iced_futures",
+ "log",
+]
+
+[[package]]
+name = "iced_devtools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b8e2a306ac5c583234b02f5404afdb7b7467c8f72a4a44ad3e7be30fc4b339"
+dependencies = [
+ "iced_debug",
+ "iced_program",
+ "iced_widget",
+ "log",
+]
+
+[[package]]
+name = "iced_futures"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c0c85ccad42dfbec7293c36c018af0ea0dbcc52d137a4a9a0b0f6822a3fdf0a"
 dependencies = [
  "futures",
  "iced_core",
@@ -2003,25 +1876,14 @@ dependencies = [
  "rustc-hash 2.1.1",
  "tokio",
  "wasm-bindgen-futures",
- "wasm-timer",
-]
-
-[[package]]
-name = "iced_glyphon"
-version = "0.6.0"
-dependencies = [
- "cosmic-text",
- "etagere",
- "lru",
- "rustc-hash 2.1.1",
- "wgpu",
+ "wasmtimer",
 ]
 
 [[package]]
 name = "iced_graphics"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba25a18cfa6d5cc160aca7e1b34f73ccdff21680fa8702168c09739767b6c66f"
+checksum = "234ca1c2cec4155055f68fa5fad1b5242c496ac8238d80a259bca382fb44a102"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
@@ -2030,47 +1892,57 @@ dependencies = [
  "iced_core",
  "iced_futures",
  "log",
- "once_cell",
  "raw-window-handle",
  "rustc-hash 2.1.1",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "unicode-segmentation",
 ]
 
 [[package]]
-name = "iced_renderer"
-version = "0.13.0"
+name = "iced_program"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73558208059f9e622df2bf434e044ee2f838ce75201a023cf0ca3e1244f46c2a"
+checksum = "6dfafec2947cda688d8eb00dac337ba11aa60f9ef6335aed343e189d26e4a673"
+dependencies = [
+ "iced_graphics",
+ "iced_runtime",
+]
+
+[[package]]
+name = "iced_renderer"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250cc0802408e8c077986ec56c7d07c65f423ee658a4b9fd795a1f2aae5dac05"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
  "iced_wgpu",
  "log",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "iced_runtime"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348b5b2c61c934d88ca3b0ed1ed913291e923d086a66fa288ce9669da9ef62b5"
+checksum = "d1889b819ce4c06674183242e336c8d49465665441396914dc07cc86f44fa8d4"
 dependencies = [
  "bytes",
  "iced_core",
  "iced_futures",
  "raw-window-handle",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "iced_tiny_skia"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c625d368284fcc43b0b36b176f76eff1abebe7959dd58bd8ce6897d641962a50"
+checksum = "fe0acf8b75a3bc914aff5f2329fdffc1b36eeaea29dda0e4bd232f1c62e9cc3d"
 dependencies = [
  "bytemuck",
  "cosmic-text",
+ "iced_debug",
  "iced_graphics",
  "kurbo",
  "log",
@@ -2081,55 +1953,53 @@ dependencies = [
 
 [[package]]
 name = "iced_wgpu"
-version = "0.13.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15708887133671d2bcc6c1d01d1f176f43a64d6cdc3b2bf893396c3ee498295f"
+checksum = "ff144a999b0ca0f8a10257934500060240825c42e950ec0ebee9c8ae30561c13"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",
+ "cryoglyph",
  "futures",
  "glam",
  "guillotiere",
- "iced_glyphon",
+ "iced_debug",
  "iced_graphics",
  "log",
- "once_cell",
  "rustc-hash 2.1.1",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "wgpu",
 ]
 
 [[package]]
 name = "iced_widget"
-version = "0.13.4"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81429e1b950b0e4bca65be4c4278fea6678ea782030a411778f26fa9f8983e1d"
+checksum = "b1596afa0d3109c2618e8bc12bae6c11d3064df8f95c42dfce570397dbe957ab"
 dependencies = [
  "iced_renderer",
- "iced_runtime",
+ "log",
  "num-traits",
- "once_cell",
  "rustc-hash 2.1.1",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "iced_winit"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44cd4e1c594b6334f409282937bf972ba14d31fedf03c23aa595d982a2fda28"
+checksum = "8b7dbedc47562d1de3b9707d939f678b88c382004b7ab5a18f7a7dd723162d75"
 dependencies = [
- "iced_futures",
- "iced_graphics",
- "iced_runtime",
+ "iced_debug",
+ "iced_program",
  "log",
+ "mundy",
  "rustc-hash 2.1.1",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tracing",
  "wasm-bindgen-futures",
  "web-sys",
- "winapi",
  "window_clipboard",
  "winit",
 ]
@@ -2167,15 +2037,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -2287,7 +2148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading 0.8.8",
+ "libloading",
  "pkg-config",
 ]
 
@@ -2327,16 +2188,6 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
-
-[[package]]
-name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
@@ -2363,6 +2214,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lilt"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67562e5eff6b20553fa9be1c503356768420994e28f67e3eafe6f41910e57ad"
+dependencies = [
+ "web-time",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,16 +2232,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a385b1be4e5c3e362ad2ffa73c392e53f031eaa5b7d648e64cd87f27f6063d7"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2445,7 +2305,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -2499,13 +2359,13 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.27.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
  "bitflags 2.10.0",
  "block",
- "core-graphics-types 0.1.3",
+ "core-graphics-types 0.2.0",
  "foreign-types",
  "log",
  "objc",
@@ -2517,16 +2377,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
 
 [[package]]
 name = "mio"
@@ -2552,7 +2402,7 @@ dependencies = [
  "libc",
  "mlua-sys",
  "num-traits",
- "parking_lot 0.12.4",
+ "parking_lot",
  "rustc-hash 2.1.1",
  "rustversion",
 ]
@@ -2571,23 +2421,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "naga"
-version = "0.19.2"
+name = "mundy"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e3524642f53d9af419ab5e8dd29d3ba155708267667c2f3f06c88c9e130843"
+checksum = "523813c9e194ec43693805214eb112551f99382115b67f38600d724a692e7e8b"
 dependencies = [
- "bit-set 0.5.3",
+ "android-build",
+ "async-io",
+ "cfg-if",
+ "dispatch",
+ "futures-channel",
+ "futures-lite",
+ "jni",
+ "ndk-context",
+ "objc2 0.6.3",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+ "pin-project-lite",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.62.2",
+ "zbus",
+]
+
+[[package]]
+name = "naga"
+version = "27.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
+dependencies = [
+ "arrayvec",
+ "bit-set 0.8.0",
  "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
  "codespan-reporting",
+ "half",
+ "hashbrown 0.16.1",
  "hexf-parse",
  "indexmap",
+ "libm",
  "log",
  "num-traits",
+ "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
- "termcolor",
- "thiserror 1.0.69",
- "unicode-xid",
+ "thiserror 2.0.17",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2599,7 +2480,7 @@ dependencies = [
  "bitflags 2.10.0",
  "jni-sys",
  "log",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -2610,15 +2491,6 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
-dependencies = [
- "jni-sys",
-]
 
 [[package]]
 name = "ndk-sys"
@@ -2637,7 +2509,20 @@ checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
  "memoffset",
 ]
@@ -2685,6 +2570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2735,7 +2621,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
 ]
 
 [[package]]
@@ -2755,19 +2640,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-app-kit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
+ "block2 0.5.1",
  "libc",
- "objc2",
- "objc2-core-data",
- "objc2-core-image",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2 0.5.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.6.2",
+ "libc",
+ "objc2 0.6.3",
+ "objc2-cloud-kit 0.3.2",
+ "objc2-core-data 0.3.2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image 0.3.2",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation 0.3.2",
+ "objc2-quartz-core 0.3.2",
 ]
 
 [[package]]
@@ -2777,10 +2692,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
- "objc2",
+ "block2 0.5.1",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2789,9 +2715,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2801,9 +2727,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2 0.6.3",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -2812,10 +2773,20 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2824,10 +2795,35 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "block2",
- "objc2",
+ "block2 0.5.1",
+ "objc2 0.5.2",
  "objc2-contacts",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]
@@ -2843,10 +2839,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
+ "block2 0.5.1",
  "dispatch",
  "libc",
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.6.2",
+ "libc",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2855,10 +2875,10 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "block2",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2868,9 +2888,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2880,10 +2900,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
  "objc2-metal",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2892,8 +2923,8 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a684efe3dec1b305badae1a28f6555f6ddd3bb2c2267896782858d5a78404dc"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2903,15 +2934,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
- "objc2",
- "objc2-cloud-kit",
- "objc2-core-data",
- "objc2-core-image",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-cloud-kit 0.2.2",
+ "objc2-core-data 0.2.2",
+ "objc2-core-image 0.2.2",
  "objc2-core-location",
- "objc2-foundation",
+ "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core",
+ "objc2-quartz-core 0.2.2",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
@@ -2923,9 +2954,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
- "block2",
- "objc2",
- "objc2-foundation",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2935,19 +2966,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.10.0",
- "block2",
- "objc2",
+ "block2 0.5.1",
+ "objc2 0.5.2",
  "objc2-core-location",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc_exception"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
-dependencies = [
- "cc",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2998,16 +3020,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-multimap"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
-dependencies = [
- "dlv-list",
- "hashbrown 0.12.3",
-]
-
-[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3023,7 +3035,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
- "ttf-parser 0.25.1",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -3037,45 +3049,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "palette"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
-dependencies = [
- "approx",
- "fast-srgb8",
- "palette_derive",
- "phf",
-]
-
-[[package]]
-name = "palette_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
-dependencies = [
- "by_address",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
 
 [[package]]
 name = "parking_lot"
@@ -3084,21 +3061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.11",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3305,19 +3268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
-
-[[package]]
 name = "polling"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3336,6 +3286,15 @@ name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -3413,7 +3372,7 @@ dependencies = [
  "bitflags 2.10.0",
  "num-traits",
  "rand 0.9.2",
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -3457,8 +3416,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -3468,18 +3425,8 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3497,9 +3444,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
 
 [[package]]
 name = "rand_core"
@@ -3562,7 +3506,7 @@ dependencies = [
  "thiserror 2.0.17",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3613,7 +3557,7 @@ dependencies = [
  "strum",
  "time",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3644,21 +3588,13 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.22.7"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69aacb76b5c29acfb7f90155d39759a29496aebb49395830e928a9703d2eec2f"
+checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
+ "core_maths",
  "font-types",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3677,17 +3613,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.10.0",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3744,16 +3669,6 @@ name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
-
-[[package]]
-name = "rust-ini"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
-]
 
 [[package]]
 name = "rustc-hash"
@@ -3958,23 +3873,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustybuzz"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
-dependencies = [
- "bitflags 2.10.0",
- "bytemuck",
- "libm",
- "smallvec",
- "ttf-parser 0.21.1",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4019,6 +3917,16 @@ name = "self_cell"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f7d95a54511e0c7be3f51e8867aa8cf35148d7b9445d44de2f943e2b206e749"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -4084,17 +3992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4151,12 +4048,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
-
-[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4164,9 +4055,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "skrifa"
-version = "0.22.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1c44ad1f6c5bdd4eefed8326711b7dbda9ea45dfd36068c427d332aa382cbe"
+checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
 dependencies = [
  "bytemuck",
  "read-fonts",
@@ -4256,17 +4147,16 @@ checksum = "18051cdd562e792cad055119e0cdb2cfc137e44e3987532e0f9659a77931bb08"
 dependencies = [
  "as-raw-xcb-connection",
  "bytemuck",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "core-graphics 0.24.0",
- "drm",
  "fastrand",
  "foreign-types",
  "js-sys",
  "log",
  "memmap2",
- "objc2",
- "objc2-foundation",
- "objc2-quartz-core",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+ "objc2-quartz-core 0.2.2",
  "raw-window-handle",
  "redox_syscall 0.5.17",
  "rustix 0.38.44",
@@ -4342,9 +4232,9 @@ checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
 name = "swash"
-version = "0.1.19"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd59f3f359ddd2c95af4758c18270eddd9c730dde98598023cdabff472c2ca2"
+checksum = "47846491253e976bdd07d0f9cc24b7daf24720d11309302ccbbc6e6b6e53550a"
 dependencies = [
  "skrifa",
  "yazi",
@@ -4443,7 +4333,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float",
@@ -4548,7 +4438,6 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "png",
  "tiny-skia-path",
 ]
 
@@ -4571,7 +4460,7 @@ checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
 dependencies = [
  "as-raw-xcb-connection",
  "ctor-lite",
- "libloading 0.8.8",
+ "libloading",
  "pkg-config",
  "tracing",
 ]
@@ -4610,7 +4499,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.4",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -4782,21 +4671,12 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
-
-[[package]]
-name = "ttf-parser"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
-
-[[package]]
-name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "typenum"
@@ -4834,18 +4714,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
-name = "unicode-bidi-mirroring"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
-
-[[package]]
-name = "unicode-ccc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4856,12 +4724,6 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-script"
@@ -4883,26 +4745,14 @@ checksum = "8fbf03860ff438702f3910ca5f28f8dac63c1c11e7efb5012b8b175493606330"
 dependencies = [
  "itertools 0.13.0",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -4925,6 +4775,7 @@ dependencies = [
  "atomic",
  "getrandom 0.3.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -5055,18 +4906,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-timer"
-version = "0.2.5"
+name = "wasmtimer"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pin-utils",
+ "slab",
  "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -5281,17 +5131,21 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.19.4"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd7311dbd2abcfebaabf1841a2824ed7c8be443a0f29166e5d3c6a53a762c01"
+checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
 dependencies = [
  "arrayvec",
+ "bitflags 2.10.0",
  "cfg-if",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
  "js-sys",
  "log",
  "naga",
- "parking_lot 0.12.4",
+ "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "smallvec",
@@ -5306,83 +5160,123 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.19.4"
+version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b94525fc99ba9e5c9a9e24764f2bc29bad0911a7446c12f446a8277369bf3a"
+checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
 dependencies = [
  "arrayvec",
- "bit-vec 0.6.3",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.10.0",
- "cfg_aliases 0.1.1",
- "codespan-reporting",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.16.1",
  "indexmap",
  "log",
  "naga",
  "once_cell",
- "parking_lot 0.12.4",
+ "parking_lot",
+ "portable-atomic",
  "profiling",
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 1.0.69",
- "web-sys",
+ "thiserror 2.0.17",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
  "wgpu-hal",
  "wgpu-types",
 ]
 
 [[package]]
-name = "wgpu-hal"
-version = "0.19.5"
+name = "wgpu-core-deps-apple"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfabcfc55fd86611a855816326b2d54c3b2fd7972c27ce414291562650552703"
+checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "27.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set 0.5.3",
+ "bit-set 0.8.0",
  "bitflags 2.10.0",
  "block",
- "cfg_aliases 0.1.1",
- "core-graphics-types 0.1.3",
- "d3d12",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
- "hassle-rs",
+ "hashbrown 0.16.1",
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading 0.8.8",
+ "libloading",
  "log",
  "metal",
  "naga",
- "ndk-sys 0.5.0+25.2.9519653",
+ "ndk-sys",
  "objc",
  "once_cell",
- "parking_lot 0.12.4",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
  "profiling",
  "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
- "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
- "winapi",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
 name = "wgpu-types"
-version = "0.19.2"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b671ff9fb03f78b46ff176494ee1ebe7d603393f42664be55b64dc8d53969805"
+checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
 dependencies = [
  "bitflags 2.10.0",
+ "bytemuck",
  "js-sys",
+ "log",
+ "thiserror 2.0.17",
  "web-sys",
 ]
 
@@ -5397,12 +5291,6 @@ dependencies = [
  "rustix 1.0.8",
  "winsafe",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"
@@ -5437,34 +5325,59 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "window_clipboard"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d692d46038c433f9daee7ad8757e002a4248c20b0a3fbc991d99521d3bcb6d"
+checksum = "d5654226305eaf2dde8853fb482861d28e5dcecbbd40cb88e8393d94bb80d733"
 dependencies = [
  "clipboard-win",
  "clipboard_macos",
  "clipboard_wayland",
  "clipboard_x11",
  "raw-window-handle",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "windows"
-version = "0.52.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core 0.52.0",
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.52.0"
+name = "windows"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
+ "windows-collections",
+ "windows-core 0.62.2",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -5474,11 +5387,46 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5486,6 +5434,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5516,6 +5475,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5525,12 +5503,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5639,6 +5645,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5827,14 +5842,14 @@ version = "0.30.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66d4b9ed69c4009f6321f762d6e61ad8a2389cd431b97cb1e146812e9e6c732"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "android-activity",
  "atomic-waker",
  "bitflags 2.10.0",
- "block2",
+ "block2 0.5.1",
  "bytemuck",
  "calloop",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "concurrent-queue",
  "core-foundation 0.9.4",
  "core-graphics 0.23.2",
@@ -5844,9 +5859,9 @@ dependencies = [
  "libc",
  "memmap2",
  "ndk",
- "objc2",
- "objc2-app-kit",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
  "objc2-ui-kit",
  "orbclient",
  "percent-encoding",
@@ -5880,15 +5895,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -5926,7 +5932,7 @@ dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
  "libc",
- "libloading 0.8.8",
+ "libloading",
  "once_cell",
  "rustix 0.38.44",
  "x11rb-protocol",
@@ -5943,16 +5949,6 @@ name = "xcursor"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec9e4a500ca8864c5b47b8b482a73d62e4237670e5b5f1d6b9e3cae50f28f2b"
-
-[[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "xkbcommon-dl"
@@ -5987,19 +5983,18 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yazi"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
+checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "zbus"
-version = "4.4.0"
+version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+checksum = "b622b18155f7a93d1cd2dc8c01d2d6a44e08fb9ebb7b3f9e6ed101488bad6c91"
 dependencies = [
  "async-broadcast",
  "async-executor",
- "async-fs",
  "async-io",
  "async-lock",
  "async-process",
@@ -6010,20 +6005,17 @@ dependencies = [
  "enumflags2",
  "event-listener",
  "futures-core",
- "futures-sink",
- "futures-util",
+ "futures-lite",
  "hex",
- "nix",
+ "nix 0.30.1",
  "ordered-stream",
- "rand 0.8.5",
  "serde",
  "serde_repr",
- "sha1",
- "static_assertions",
  "tracing",
  "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -6031,33 +6023,35 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "4.4.0"
+version = "5.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+checksum = "04f54d8a5b4e9c46cf4a9732da4899b12851b5df952fc8deda23aca1d6f3e26c"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
+ "zbus_names",
+ "zvariant",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zbus_names"
-version = "3.0.0"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
- "static_assertions",
+ "winnow",
  "zvariant",
 ]
 
 [[package]]
 name = "zeno"
-version = "0.2.3"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
+checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"
@@ -6107,22 +6101,23 @@ checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
 
 [[package]]
 name = "zvariant"
-version = "4.2.0"
+version = "5.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+checksum = "326aaed414f04fe839777b4c443d4e94c74e7b3621093bd9c5e649ac8aa96543"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "static_assertions",
+ "winnow",
  "zvariant_derive",
+ "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "4.2.0"
+version = "5.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+checksum = "ba44e1f8f4da9e6e2d25d2a60b116ef8b9d0be174a7685e55bb12a99866279a7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -6133,11 +6128,17 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "2.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
 dependencies = [
  "proc-macro2",
  "quote",
+ "serde",
  "syn 2.0.106",
+ "winnow",
 ]
+
+[[patch.unused]]
+name = "iced_glyphon"
+version = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,8 @@ open = "5.3.3"
 clipboard = "0.5"
 
 # UI
-# Note: iced remains at 0.13.1 - v0.14.0 has extensive breaking changes requiring major code refactoring
-# (see PR #45 - excluded from consolidation due to scope)
-iced = { version = "0.13.1", features = ["tokio", "debug", "advanced"] }
+# iced 0.14.0 - Major release with reactive rendering, time-travel debugging, and API improvements
+iced = { version = "0.14.0", features = ["tokio", "debug", "advanced"] }
 ratatui = "0.30.0"
 crossterm = "0.29"
 

--- a/crates/rustirc-gui/src/app.rs
+++ b/crates/rustirc-gui/src/app.rs
@@ -2,7 +2,7 @@
 //!
 //! This module implements the complete Iced GUI application for RustIRC.
 //! Features:
-//! - Multi-server IRC client interface using Iced 0.13.1 functional API
+//! - Multi-server IRC client interface using Iced 0.14.0 functional API
 //! - Resizable panels with server tree, message view, and user lists
 //! - Comprehensive tab system for channels and private messages
 //! - Full IRC message formatting with colors and styles
@@ -22,8 +22,8 @@ use crate::widgets::{
 };
 use iced::{
     widget::{
-        button, column, container, horizontal_rule, mouse_area, pane_grid, row, scrollable, stack,
-        text, text_input,
+        button, column, container, mouse_area, pane_grid, row, rule, scrollable, stack, text,
+        text_input,
     },
     Background, Color, Element, Length, Task,
 };
@@ -2337,7 +2337,7 @@ impl RustIrcGui {
             let dialog = container(
                 column![
                     text("Preferences").size(18).color(Color::WHITE),
-                    horizontal_rule(1),
+                    rule::horizontal(1),
                     text("Theme Settings")
                         .size(14)
                         .color(Color::from_rgb(0.8, 0.8, 0.8)),
@@ -2350,7 +2350,7 @@ impl RustIrcGui {
                     text("• Auto-connect: Disabled")
                         .size(12)
                         .color(Color::from_rgb(0.7, 0.7, 0.7)),
-                    horizontal_rule(1),
+                    rule::horizontal(1),
                     text("IRC Settings")
                         .size(14)
                         .color(Color::from_rgb(0.8, 0.8, 0.8)),
@@ -2363,7 +2363,7 @@ impl RustIrcGui {
                     text("• SASL Authentication: Enabled")
                         .size(12)
                         .color(Color::from_rgb(0.7, 0.7, 0.7)),
-                    horizontal_rule(1),
+                    rule::horizontal(1),
                     button("Close")
                         .on_press(Message::HidePreferencesDialog)
                         .padding([8, 16])
@@ -2401,21 +2401,21 @@ impl RustIrcGui {
             let dialog = container(
                 column![
                     text("About RustIRC").size(18).color(Color::WHITE),
-                    horizontal_rule(1),
+                    rule::horizontal(1),
                     text("RustIRC v0.1.0")
                         .size(16)
                         .color(Color::from_rgb(0.9, 0.9, 0.9)),
                     text("Modern IRC Client")
                         .size(14)
                         .color(Color::from_rgb(0.8, 0.8, 0.8)),
-                    horizontal_rule(1),
+                    rule::horizontal(1),
                     text("Built with Rust and Iced")
                         .size(12)
                         .color(Color::from_rgb(0.7, 0.7, 0.7)),
                     text("© 2025 RustIRC Project")
                         .size(12)
                         .color(Color::from_rgb(0.7, 0.7, 0.7)),
-                    horizontal_rule(1),
+                    rule::horizontal(1),
                     text("Features:")
                         .size(14)
                         .color(Color::from_rgb(0.8, 0.8, 0.8)),
@@ -2434,7 +2434,7 @@ impl RustIrcGui {
                     text("• Modern Theming")
                         .size(12)
                         .color(Color::from_rgb(0.7, 0.7, 0.7)),
-                    horizontal_rule(1),
+                    rule::horizontal(1),
                     button("Close")
                         .on_press(Message::HideAboutDialog)
                         .padding([8, 16])
@@ -2506,15 +2506,16 @@ impl RustIrcGui {
         })
     }
 
-    /// Run the GUI application using Iced 0.13.1 Application trait
+    /// Run the GUI application using Iced 0.14.0 Application trait
     pub fn run() -> iced::Result {
-        iced::application("RustIRC - Modern IRC Client", Self::update, Self::view)
+        iced::application(Self::new, Self::update, Self::view)
+            .title("RustIRC - Modern IRC Client")
             .subscription(Self::subscription)
             .theme(Self::theme)
             .run()
     }
 
-    /// Theme function for Iced 0.13.1
+    /// Theme function for Iced 0.14.0
     fn theme(&self) -> iced::Theme {
         match self.current_theme.theme_type {
             ThemeType::Dark => iced::Theme::Dark,
@@ -2606,7 +2607,7 @@ impl RustIrcGui {
                         .on_press(Message::MenuFileDisconnect)
                         .width(Length::Fixed(120.0))
                         .padding([4, 8]),
-                    horizontal_rule(1),
+                    rule::horizontal(1),
                     button(text("Exit").size(12))
                         .on_press(Message::MenuFileExit)
                         .width(Length::Fixed(120.0))
@@ -2744,6 +2745,7 @@ impl RustIrcGui {
                 background: None,
                 text_color: None,
                 shadow: iced::Shadow::default(),
+                snap: true,
             })
             .width(Length::Fill)
             .height(Length::Fill);

--- a/crates/rustirc-gui/src/components/atoms/button.rs
+++ b/crates/rustirc-gui/src/components/atoms/button.rs
@@ -201,6 +201,7 @@ impl<Message> MaterialButton<Message> {
                         radius: button_clone.theme.shapes.corner_large.into(),
                     },
                     shadow: button_clone.get_shadow_for_status(status),
+                    snap: true,
                 }
             });
 
@@ -579,6 +580,7 @@ impl<Message> FloatingActionButton<Message> {
                         radius: self.theme.shapes.corner_large.into(),
                     },
                     shadow,
+                    snap: true,
                 }
             });
 

--- a/crates/rustirc-gui/src/components/atoms/input.rs
+++ b/crates/rustirc-gui/src/components/atoms/input.rs
@@ -156,7 +156,7 @@ impl<'a, Message: 'a + Clone> MaterialInput<'a, Message> {
         let theme_clone = theme.clone();
 
         let styled_input = input.style(move |_theme: &Theme, status| {
-            let is_focused = matches!(status, text_input::Status::Focused);
+            let is_focused = matches!(status, text_input::Status::Focused { .. });
 
             let (background_color, border_color, border_width) =
                 match (&variant, is_focused, has_error, is_enabled) {

--- a/crates/rustirc-gui/src/components/molecules/message_bubble.rs
+++ b/crates/rustirc-gui/src/components/molecules/message_bubble.rs
@@ -281,6 +281,7 @@ impl MessageBubble {
                 } else {
                     Default::default()
                 },
+                snap: true,
             });
 
         // Add hover and click interactions

--- a/crates/rustirc-gui/src/components/molecules/search_bar.rs
+++ b/crates/rustirc-gui/src/components/molecules/search_bar.rs
@@ -144,7 +144,7 @@ impl<'a, Message: 'a + Clone> MaterialSearchBar<'a, Message> {
         }
 
         let styled_input = search_input.style(move |_theme: &Theme, status| {
-            let _is_focused = matches!(status, text_input::Status::Focused);
+            let _is_focused = matches!(status, text_input::Status::Focused { .. });
 
             text_input::Style {
                 background: Background::Color(Color::TRANSPARENT),

--- a/crates/rustirc-gui/src/components/organisms/responsive_layout.rs
+++ b/crates/rustirc-gui/src/components/organisms/responsive_layout.rs
@@ -1,5 +1,5 @@
 use iced::{
-    widget::{column, container, horizontal_space, pane_grid, row, scrollable},
+    widget::{column, container, pane_grid, row, scrollable, Space},
     Background, Border, Element, Length, Renderer, Size, Theme,
 };
 use pane_grid::{Axis, PaneGrid, State};
@@ -187,7 +187,7 @@ impl ResponsiveLayout {
             // Overlay layout
             container(row![
                 sidebar_overlay,
-                horizontal_space().width(Length::FillPortion(1))
+                Space::new().width(Length::FillPortion(1))
             ])
             .width(Length::Fill)
             .height(Length::Fill)
@@ -603,23 +603,23 @@ impl ResponsiveLayout {
         self.pane_state = new_state;
     }
 
-    fn adaptive_spacing(&self) -> u16 {
+    fn adaptive_spacing(&self) -> f32 {
         if self.adaptive_spacing {
             match self.current_breakpoint {
-                Breakpoint::Compact => 8,
-                Breakpoint::Medium => 12,
-                _ => 16,
+                Breakpoint::Compact => 8.0,
+                Breakpoint::Medium => 12.0,
+                _ => 16.0,
             }
         } else {
-            16
+            16.0
         }
     }
 
-    fn adaptive_padding(&self) -> u16 {
+    fn adaptive_padding(&self) -> f32 {
         match self.current_breakpoint {
-            Breakpoint::Compact => 8,
-            Breakpoint::Medium => 12,
-            _ => 16,
+            Breakpoint::Compact => 8.0,
+            Breakpoint::Medium => 12.0,
+            _ => 16.0,
         }
     }
 

--- a/crates/rustirc-gui/src/components/organisms/rich_text_editor.rs
+++ b/crates/rustirc-gui/src/components/organisms/rich_text_editor.rs
@@ -355,7 +355,7 @@ impl RichTextEditor {
                     text_input::Status::Hovered => {
                         iced::Color::from(self.theme.scheme.surface_container_highest)
                     }
-                    text_input::Status::Focused => {
+                    text_input::Status::Focused { .. } => {
                         iced::Color::from(self.theme.scheme.surface_container_highest)
                     }
                     text_input::Status::Disabled => {
@@ -367,12 +367,12 @@ impl RichTextEditor {
                     background: Background::Color(background_color),
                     border: Border {
                         color: match status {
-                            text_input::Status::Focused => {
+                            text_input::Status::Focused { .. } => {
                                 iced::Color::from(self.theme.scheme.primary)
                             }
                             _ => iced::Color::from(self.theme.scheme.outline),
                         },
-                        width: if matches!(status, text_input::Status::Focused) {
+                        width: if matches!(status, text_input::Status::Focused { .. }) {
                             2.0
                         } else {
                             1.0

--- a/crates/rustirc-gui/src/dialogs.rs
+++ b/crates/rustirc-gui/src/dialogs.rs
@@ -6,8 +6,8 @@
 use crate::state::AppState;
 use crate::theme::Theme;
 use iced::widget::{
-    button, checkbox, column, container, horizontal_space, pick_list, row, scrollable, slider,
-    text, text_input, vertical_space, Space,
+    button, checkbox, column, container, pick_list, row, scrollable, slider, text, text_input,
+    Space,
 };
 use iced::{Element, Length, Size, Task};
 use rustirc_core::connection::ConnectionConfig;
@@ -414,7 +414,7 @@ impl ConnectionDialog {
 
         let content = column![
             text("Connect to IRC Server").size(20),
-            vertical_space().height(10),
+            Space::new().height(10),
             row![
                 text("Server:").width(80),
                 text_input("irc.libera.chat", &self.server)
@@ -458,19 +458,22 @@ impl ConnectionDialog {
                     .width(200),
             ]
             .spacing(10),
-            checkbox("Use TLS/SSL", self.use_tls).on_toggle(DialogMessage::ConnectionUseTlsToggled),
-            checkbox("Auto-connect on startup", self.auto_connect)
+            checkbox(self.use_tls)
+                .label("Use TLS/SSL")
+                .on_toggle(DialogMessage::ConnectionUseTlsToggled),
+            checkbox(self.auto_connect)
+                .label("Auto-connect on startup")
                 .on_toggle(DialogMessage::ConnectionAutoConnectToggled),
-            vertical_space().height(20),
+            Space::new().height(20),
             row![
                 button(text("Connect")).on_press(DialogMessage::ConnectionConnect),
-                horizontal_space().width(10),
+                Space::new().width(10),
                 button(text("Cancel")).on_press(DialogMessage::ConnectionCancel),
             ],
         ]
         .spacing(10)
         .padding(20)
-        .max_width(max_size.width as u16); // Use Size for maximum constraints
+        .max_width(max_size.width); // Use Size for maximum constraints
 
         // Apply theme styling to the container
         let theme_style = Theme::from_type(crate::theme::ThemeType::default());
@@ -517,7 +520,7 @@ impl JoinChannelDialog {
     pub fn build(&self) -> Element<'_, DialogMessage> {
         let content = column![
             text("Join Channel").size(20),
-            vertical_space().height(10),
+            Space::new().height(10),
             row![
                 text("Channel:").width(80),
                 text_input("#channel", &self.channel)
@@ -532,10 +535,10 @@ impl JoinChannelDialog {
                     .width(200),
             ]
             .spacing(10),
-            vertical_space().height(20),
+            Space::new().height(20),
             row![
                 button(text("Join")).on_press(DialogMessage::JoinChannel),
-                horizontal_space().width(10),
+                Space::new().width(10),
                 button(text("Cancel")).on_press(DialogMessage::JoinCancel),
             ],
         ]
@@ -635,7 +638,7 @@ impl PreferencesDialog {
 
         let content = column![
             text("Preferences").size(20),
-            vertical_space().height(10),
+            Space::new().height(10),
             text("Appearance").size(16),
             row![
                 text("Theme:").width(120),
@@ -654,24 +657,29 @@ impl PreferencesDialog {
                     .width(100),
             ]
             .spacing(10),
-            vertical_space().height(10),
+            Space::new().height(10),
             text("Notifications").size(16),
-            checkbox("Sound notifications", self.notification_sound)
+            checkbox(self.notification_sound)
+                .label("Sound notifications")
                 .on_toggle(DialogMessage::PreferencesNotificationSoundToggled),
-            checkbox("Popup notifications", self.notification_popup)
+            checkbox(self.notification_popup)
+                .label("Popup notifications")
                 .on_toggle(DialogMessage::PreferencesNotificationPopupToggled),
-            vertical_space().height(10),
+            Space::new().height(10),
             text("Display").size(16),
-            checkbox("Show timestamps", self.show_timestamps)
+            checkbox(self.show_timestamps)
+                .label("Show timestamps")
                 .on_toggle(DialogMessage::PreferencesShowTimestampsToggled),
-            checkbox("Colored nicknames", self.nick_colors)
+            checkbox(self.nick_colors)
+                .label("Colored nicknames")
                 .on_toggle(DialogMessage::PreferencesNickColorsToggled),
-            checkbox("Compact mode", self.compact_mode)
+            checkbox(self.compact_mode)
+                .label("Compact mode")
                 .on_toggle(DialogMessage::PreferencesCompactModeToggled),
-            vertical_space().height(20),
+            Space::new().height(20),
             row![
                 button(text("Apply")).on_press(DialogMessage::PreferencesApply),
-                horizontal_space().width(10),
+                Space::new().width(10),
                 button(text("Cancel")).on_press(DialogMessage::PreferencesCancel),
             ],
         ]
@@ -727,35 +735,39 @@ impl PreferencesDialog {
             DialogMessage::PreferencesFontSizeChanged(size.to_string())
         });
 
-        let notification_checkbox = checkbox("Enable notifications", settings.notification_sound)
+        let notification_checkbox = checkbox(settings.notification_sound)
+            .label("Enable notifications")
             .on_toggle(DialogMessage::PreferencesNotificationSoundToggled);
 
-        let compact_checkbox = checkbox("Compact mode", settings.compact_mode)
+        let compact_checkbox = checkbox(settings.compact_mode)
+            .label("Compact mode")
             .on_toggle(DialogMessage::PreferencesCompactModeToggled);
 
-        let timestamps_checkbox = checkbox("Show timestamps", settings.show_timestamps)
+        let timestamps_checkbox = checkbox(settings.show_timestamps)
+            .label("Show timestamps")
             .on_toggle(DialogMessage::PreferencesShowTimestampsToggled);
 
-        let nick_colors_checkbox = checkbox("Nick colors", settings.nick_colors)
+        let nick_colors_checkbox = checkbox(settings.nick_colors)
+            .label("Nick colors")
             .on_toggle(DialogMessage::PreferencesNickColorsToggled);
 
         let content = column![
             text("Preferences").size(20),
-            Space::with_height(10),
+            Space::new().height(10),
             text("Theme:"),
             theme_picker,
-            Space::with_height(10),
+            Space::new().height(10),
             text(format!("Font Size: {:.0}", settings.font_size)),
             font_size_slider,
-            Space::with_height(10),
+            Space::new().height(10),
             notification_checkbox,
             compact_checkbox,
             timestamps_checkbox,
             nick_colors_checkbox,
-            Space::with_height(20),
+            Space::new().height(20),
             row![
                 button("Apply").on_press(DialogMessage::PreferencesApply),
-                Space::with_width(10),
+                Space::new().width(10),
                 button("Cancel").on_press(DialogMessage::PreferencesCancel),
             ]
             .spacing(10)
@@ -792,15 +804,15 @@ impl AboutDialog {
         let content = column![
             text("RustIRC").size(24),
             text("Modern IRC Client").size(16),
-            vertical_space().height(10),
+            Space::new().height(10),
             text("Version 1.0.0"),
             text("Built with Rust and Iced"),
-            vertical_space().height(10),
+            Space::new().height(10),
             text("A modern IRC client combining the best features"),
             text("of mIRC, HexChat, and WeeChat."),
-            vertical_space().height(20),
+            Space::new().height(20),
             text("© 2025 RustIRC Project"),
-            vertical_space().height(20),
+            Space::new().height(20),
             button(text("OK")).on_press(DialogMessage::AboutOk),
         ]
         .spacing(5)
@@ -842,7 +854,7 @@ impl FindDialog {
     pub fn build(&self) -> Element<'_, DialogMessage> {
         let content = column![
             text("Find").size(20),
-            vertical_space().height(10),
+            Space::new().height(10),
             row![
                 text("Find:").width(60),
                 text_input("Search text", &self.query)
@@ -850,15 +862,18 @@ impl FindDialog {
                     .width(250),
             ]
             .spacing(10),
-            checkbox("Case sensitive", self.case_sensitive)
+            checkbox(self.case_sensitive)
+                .label("Case sensitive")
                 .on_toggle(DialogMessage::FindCaseSensitiveToggled),
-            checkbox("Regular expression", self.regex).on_toggle(DialogMessage::FindRegexToggled),
-            vertical_space().height(20),
+            checkbox(self.regex)
+                .label("Regular expression")
+                .on_toggle(DialogMessage::FindRegexToggled),
+            Space::new().height(20),
             row![
                 button(text("Find Next")).on_press(DialogMessage::FindNext),
-                horizontal_space().width(10),
+                Space::new().width(10),
                 button(text("Find Previous")).on_press(DialogMessage::FindPrevious),
-                horizontal_space().width(10),
+                Space::new().width(10),
                 button(text("Close")).on_press(DialogMessage::FindClose),
             ],
         ]
@@ -933,17 +948,17 @@ impl NetworkListDialog {
 
         let content = column![
             text("Network List").size(20),
-            vertical_space().height(10),
+            Space::new().height(10),
             row![
                 text("Network").width(150),
                 text("Servers").width(200),
                 text("Actions"),
             ],
             network_list.height(300),
-            vertical_space().height(10),
+            Space::new().height(10),
             row![
                 button(text("Add Network")).on_press(DialogMessage::NetworkListAdd),
-                horizontal_space().width(Length::Fill),
+                Space::new().width(Length::Fill),
                 button(text("Close")).on_press(DialogMessage::NetworkListClose),
             ],
         ]

--- a/crates/rustirc-gui/src/material_demo.rs
+++ b/crates/rustirc-gui/src/material_demo.rs
@@ -35,7 +35,8 @@ enum Message {
 
 /// Run the Material Design 3 demo using Iced functional API
 pub fn run() -> iced::Result {
-    iced::application("RustIRC - Material Design 3 Demo", update, view)
+    iced::application(MaterialDemoState::default, update, view)
+        .title("RustIRC - Material Design 3 Demo")
         .theme(theme)
         .run()
 }
@@ -67,28 +68,28 @@ fn view(state: &MaterialDemoState) -> Element<'_, Message> {
         column![
             // Typography Section
             typography_section(&state.theme),
-            Space::with_height(20),
+            Space::new().height(20),
             // Buttons Section
             buttons_section(&state.theme),
-            Space::with_height(20),
+            Space::new().height(20),
             // Input Section
             input_section(&state.theme, &state.text_input_value),
-            Space::with_height(20),
+            Space::new().height(20),
             // Chips Section
             chips_section(&state.theme, state.selected_chip),
-            Space::with_height(20),
+            Space::new().height(20),
             // Cards Section
             cards_section(&state.theme),
-            Space::with_height(20),
+            Space::new().height(20),
             // Search Bar
             search_section(&state.theme, &state.search_value),
-            Space::with_height(20),
+            Space::new().height(20),
             // List Items
             list_items_section(&state.theme),
-            Space::with_height(20),
+            Space::new().height(20),
             // Message Bubbles
             message_bubbles_section(&state.theme),
-            Space::with_height(100), // Extra space for bottom navigation
+            Space::new().height(100), // Extra space for bottom navigation
         ]
         .padding(20)
         .spacing(10)

--- a/crates/rustirc-gui/src/widgets/input_area.rs
+++ b/crates/rustirc-gui/src/widgets/input_area.rs
@@ -221,7 +221,7 @@ impl InputArea {
         // Main input row
         let input_row = row![
             input_field,
-            Space::with_width(Length::Fixed(8.0)),
+            Space::new().width(Length::Fixed(8.0)),
             send_button
         ]
         .align_y(Alignment::Center);
@@ -229,7 +229,7 @@ impl InputArea {
         // Info row (format and completion hints)
         let info_row = row![
             format_info,
-            Space::with_width(Length::Fill),
+            Space::new().width(Length::Fill),
             completion_hint
         ]
         .align_y(Alignment::Center);
@@ -258,11 +258,11 @@ impl InputArea {
                 row![send_button, toggle_button,]
                     .spacing(5)
                     .align_y(Alignment::Center),
-                Space::with_height(Length::Fixed(4.0)),
+                Space::new().height(Length::Fixed(4.0)),
                 info_row
             ]
         } else {
-            column![input_row, Space::with_height(Length::Fixed(4.0)), info_row]
+            column![input_row, Space::new().height(Length::Fixed(4.0)), info_row]
         };
 
         container(content).padding(8).width(Length::Fill).into()

--- a/crates/rustirc-gui/src/widgets/message_view.rs
+++ b/crates/rustirc-gui/src/widgets/message_view.rs
@@ -8,7 +8,7 @@ use crate::state::{AppState, DisplayMessage, MessageType};
 use crate::theme::Theme;
 use iced::{
     font::{Style as FontStyle, Weight},
-    widget::{button, column, container, row, scrollable, text, Space},
+    widget::{button, column, container, operation, row, scrollable, text, Id, Space},
     Alignment, Background, Color, Element, Length, Task,
 };
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -42,7 +42,7 @@ pub struct MessageView {
     show_user_lists: bool,
     show_motd: bool,
     compact_mode: bool,
-    scroll_id: scrollable::Id,
+    scroll_id: Id,
 }
 
 impl MessageView {
@@ -59,7 +59,7 @@ impl MessageView {
             show_user_lists: false,      // Hide user list spam by default
             show_motd: true,
             compact_mode: false,
-            scroll_id: scrollable::Id::unique(),
+            scroll_id: Id::unique(),
         }
     }
 
@@ -73,13 +73,13 @@ impl MessageView {
             MessageViewMessage::ScrollToBottom => {
                 self.auto_scroll = true;
                 self.scroll_position = 1.0;
-                scrollable::snap_to(self.scroll_id.clone(), scrollable::RelativeOffset::END)
+                operation::snap_to(self.scroll_id.clone(), scrollable::RelativeOffset::END)
                     .map(|_: ()| MessageViewMessage::NoOp)
             }
             MessageViewMessage::ScrollToTop => {
                 self.auto_scroll = false;
                 self.scroll_position = 0.0;
-                scrollable::snap_to(self.scroll_id.clone(), scrollable::RelativeOffset::START)
+                operation::snap_to(self.scroll_id.clone(), scrollable::RelativeOffset::START)
                     .map(|_: ()| MessageViewMessage::NoOp)
             }
             MessageViewMessage::MessageClicked(index) => {
@@ -209,7 +209,7 @@ impl MessageView {
                         text("Welcome to RustIRC")
                             .size(24)
                             .color(theme.get_primary_color()),
-                        Space::with_height(Length::Fixed(16.0)),
+                        Space::new().height(Length::Fixed(16.0)),
                         text("Connect to a server to start chatting")
                             .size(14)
                             .color(theme.get_text_color()),
@@ -281,7 +281,7 @@ impl MessageView {
                 .color(Color::from_rgb(0.5, 0.5, 0.5))
                 .into()
         } else {
-            Space::with_width(Length::Fixed(0.0)).into()
+            Space::new().width(Length::Fixed(0.0)).into()
         };
 
         // Build sender
@@ -321,7 +321,7 @@ impl MessageView {
                 .color(sender_color)
                 .into()
         } else {
-            Space::with_width(Length::Fixed(0.0)).into()
+            Space::new().width(Length::Fixed(0.0)).into()
         };
 
         // Build message content
@@ -334,12 +334,12 @@ impl MessageView {
                 .align_y(Alignment::Center)
         } else {
             row![
-                column![timestamp_element, Space::with_height(Length::Fixed(2.0))]
+                column![timestamp_element, Space::new().height(Length::Fixed(2.0))]
                     .width(Length::Fixed(80.0))
                     .align_x(Alignment::End),
-                column![sender_element, Space::with_height(Length::Fixed(2.0))]
+                column![sender_element, Space::new().height(Length::Fixed(2.0))]
                     .width(Length::Fixed(120.0)),
-                column![content_element, Space::with_height(Length::Fixed(2.0))]
+                column![content_element, Space::new().height(Length::Fixed(2.0))]
                     .width(Length::Fill)
             ]
             .spacing(8)
@@ -475,7 +475,7 @@ impl MessageView {
     /// Create a task to scroll to bottom
     pub fn create_scroll_to_bottom_task(&self) -> Task<MessageViewMessage> {
         if self.auto_scroll {
-            scrollable::snap_to(self.scroll_id.clone(), scrollable::RelativeOffset::END)
+            operation::snap_to(self.scroll_id.clone(), scrollable::RelativeOffset::END)
                 .map(|_: ()| MessageViewMessage::NoOp)
         } else {
             Task::none()

--- a/crates/rustirc-gui/src/widgets/server_tree.rs
+++ b/crates/rustirc-gui/src/widgets/server_tree.rs
@@ -103,7 +103,10 @@ impl ServerTree {
             let server_indicator = self.get_connection_indicator(&server_state.connection_state);
             let server_name = text(server_id.clone()).size(14);
             let expand_button: Element<ServerTreeMessage> = if server_state.channels.is_empty() {
-                Space::new(Length::Fixed(16.0), Length::Fixed(16.0)).into()
+                Space::new()
+                    .width(Length::Fixed(16.0))
+                    .height(Length::Fixed(16.0))
+                    .into()
             } else if is_expanded {
                 button(text("▼").size(12))
                     .on_press(ServerTreeMessage::CollapseServer(server_id.clone()))
@@ -161,10 +164,12 @@ impl ServerTree {
 
                     let channel_row = button(
                         row![
-                            Space::new(Length::Fixed(24.0), Length::Fixed(16.0)),
+                            Space::new()
+                                .width(Length::Fixed(24.0))
+                                .height(Length::Fixed(16.0)),
                             text("#").size(12).color(Color::from_rgb(0.6, 0.6, 0.6)),
                             channel_name_style,
-                            Space::with_width(Length::Fill),
+                            Space::new().width(Length::Fill),
                             activity_indicator
                         ]
                         .spacing(4)
@@ -204,10 +209,12 @@ impl ServerTree {
 
                             let pm_row = button(
                                 row![
-                                    Space::new(Length::Fixed(24.0), Length::Fixed(16.0)),
+                                    Space::new()
+                                        .width(Length::Fixed(24.0))
+                                        .height(Length::Fixed(16.0)),
                                     text("@").size(12).color(Color::from_rgb(0.6, 0.6, 0.6)),
                                     nick_style,
-                                    Space::with_width(Length::Fill),
+                                    Space::new().width(Length::Fill),
                                     activity_indicator
                                 ]
                                 .spacing(4)

--- a/crates/rustirc-gui/src/widgets/status_bar.rs
+++ b/crates/rustirc-gui/src/widgets/status_bar.rs
@@ -102,10 +102,10 @@ impl StatusBar {
                 .color(theme.get_text_color()),
         );
 
-        status_content = status_content.push(Space::with_width(Length::Fixed(8.0)));
+        status_content = status_content.push(Space::new().width(Length::Fixed(8.0)));
         status_content =
             status_content.push(text("|").size(11.0).color(Color::from_rgb(0.5, 0.5, 0.5)));
-        status_content = status_content.push(Space::with_width(Length::Fixed(8.0)));
+        status_content = status_content.push(Space::new().width(Length::Fixed(8.0)));
 
         // Tab-specific information
         if let Some(tab) = current_tab {
@@ -120,7 +120,7 @@ impl StatusBar {
             if let TabType::Channel { .. } = tab.tab_type {
                 if self.show_user_count {
                     let user_count = tab.users.len();
-                    status_content = status_content.push(Space::with_width(Length::Fixed(8.0)));
+                    status_content = status_content.push(Space::new().width(Length::Fixed(8.0)));
                     status_content = status_content.push(
                         text(format!("({user_count} users)"))
                             .size(11.0)
@@ -135,7 +135,7 @@ impl StatusBar {
                     if let Some(server_state) = app_state.servers.get(server_id) {
                         if !server_state.modes.is_empty() {
                             status_content =
-                                status_content.push(Space::with_width(Length::Fixed(8.0)));
+                                status_content.push(Space::new().width(Length::Fixed(8.0)));
                             status_content = status_content.push(
                                 text(format!("+{}", server_state.modes.join("")))
                                     .size(11.0)
@@ -148,7 +148,7 @@ impl StatusBar {
         }
 
         // Spacer
-        status_content = status_content.push(Space::with_width(Length::Fill));
+        status_content = status_content.push(Space::new().width(Length::Fill));
 
         // Lag information
         if self.show_lag {
@@ -159,7 +159,7 @@ impl StatusBar {
                         .size(11.0)
                         .color(Color::from_rgb(0.6, 0.6, 0.6)),
                 );
-                status_content = status_content.push(Space::with_width(Length::Fixed(8.0)));
+                status_content = status_content.push(Space::new().width(Length::Fixed(8.0)));
             }
         }
 
@@ -306,7 +306,7 @@ impl StatusBar {
                                         text("Topic:")
                                             .size(11.0)
                                             .color(Color::from_rgb(0.6, 0.6, 0.6)),
-                                        Space::with_width(Length::Fixed(8.0)),
+                                        Space::new().width(Length::Fixed(8.0)),
                                         text(topic_text)
                                             .size(11.0)
                                             .color(Color::from_rgb(0.8, 0.8, 0.8))

--- a/crates/rustirc-gui/src/widgets/tab_bar.rs
+++ b/crates/rustirc-gui/src/widgets/tab_bar.rs
@@ -245,10 +245,10 @@ impl TabBar {
         .height(Length::Fixed(30.0))
         .padding(0);
 
-        tab_row = tab_row.push(Space::with_width(Length::Fixed(4.0)));
+        tab_row = tab_row.push(Space::new().width(Length::Fixed(4.0)));
         tab_row = tab_row.push(new_tab_button);
         // Remove Length::Fill space to prevent horizontal scrollable issue
-        tab_row = tab_row.push(Space::with_width(Length::Fixed(10.0)));
+        tab_row = tab_row.push(Space::new().width(Length::Fixed(10.0)));
 
         let content: Element<TabBarMessage> = if self.scrollable {
             scrollable(tab_row)
@@ -297,7 +297,7 @@ impl TabBar {
         // Activity indicator with visual feedback
         if let Some(indicator_color) = activity_indicator {
             // Create activity indicator with proper color
-            let indicator = container(Space::with_width(Length::Fixed(4.0)))
+            let indicator = container(Space::new().width(Length::Fixed(4.0)))
                 .width(Length::Fixed(4.0))
                 .height(Length::Fixed(20.0))
                 .style(move |_theme| container::Style {
@@ -311,13 +311,13 @@ impl TabBar {
                 });
 
             tab_content = tab_content.push(indicator);
-            tab_content = tab_content.push(Space::with_width(Length::Fixed(4.0)));
+            tab_content = tab_content.push(Space::new().width(Length::Fixed(4.0)));
         }
 
         // Tab icon (if not compact)
         if !self.compact_mode && !icon.is_empty() {
             tab_content = tab_content.push(text(icon).size(12.0).color(text_color));
-            tab_content = tab_content.push(Space::with_width(Length::Fixed(4.0)));
+            tab_content = tab_content.push(Space::new().width(Length::Fixed(4.0)));
         }
 
         // Tab title
@@ -337,7 +337,7 @@ impl TabBar {
 
         // Close button
         if self.show_close_buttons && !matches!(tab.tab_type, TabType::Server) {
-            tab_content = tab_content.push(Space::with_width(Length::Fixed(4.0)));
+            tab_content = tab_content.push(Space::new().width(Length::Fixed(4.0)));
             tab_content = tab_content.push(
                 button(text("×").size(14.0).color(Color::from_rgb(0.8, 0.8, 0.8)))
                     .on_press(TabBarMessage::CloseTab(tab_id.to_string()))

--- a/crates/rustirc-gui/src/widgets/user_list.rs
+++ b/crates/rustirc-gui/src/widgets/user_list.rs
@@ -207,7 +207,7 @@ impl UserList {
                 ..iced::Font::default()
             }))
             .on_press(UserListMessage::SortByNick),
-            Space::with_width(Length::Fill),
+            Space::new().width(Length::Fill),
             text(format!("{}", users.len()))
                 .size(10.0)
                 .color(Color::from_rgb(0.6, 0.6, 0.6))
@@ -252,7 +252,7 @@ impl UserList {
             row![
                 text(privilege_symbol).size(10.0).color(privilege_color),
                 text(nick.to_string()).size(12.0).color(nick_color),
-                Space::with_width(Length::Fill),
+                Space::new().width(Length::Fill),
                 away_indicator
             ]
             .spacing(4)
@@ -302,7 +302,7 @@ impl UserList {
                     ..iced::Font::default()
                 })
                 .color(Color::from_rgb(0.7, 0.7, 0.7)),
-            Space::with_height(Length::Fixed(8.0)),
+            Space::new().height(Length::Fixed(8.0)),
             text(nick.to_string())
                 .size(14.0)
                 .color(Color::from_rgb(0.9, 0.9, 0.9)),
@@ -321,7 +321,7 @@ impl UserList {
                     ..iced::Font::default()
                 })
                 .color(Color::from_rgb(0.7, 0.7, 0.7)),
-            Space::with_height(Length::Fixed(8.0)),
+            Space::new().height(Length::Fixed(8.0)),
             text("No channel selected")
                 .size(11.0)
                 .color(Color::from_rgb(0.6, 0.6, 0.6)),


### PR DESCRIPTION
## Summary

Complete migration of the rustirc-gui crate from iced 0.13.1 to iced 0.14.0, resolving 82+ breaking API changes across 18 files. This is a major framework upgrade that brings reactive rendering improvements, time-travel debugging capabilities, and enhanced API design to the RustIRC GUI.

### Breaking API Changes Resolved

| Category | Old API | New API |
|----------|---------|---------|
| Space Widget | `Space::with_width/with_height` | `Space::new().width/height()` |
| Application | `iced::application(title, update, view)` | `iced::application(boot_fn, update, view).title()` |
| Space Helpers | `horizontal_space()`, `vertical_space()` | `Space::new().width/height(Length::Fill)` |
| Rule Widget | `horizontal_rule(height)` | `rule::horizontal(height)` |
| Checkbox | `checkbox(label, value)` | `checkbox(value).label(label)` |
| Scrollable ID | `scrollable::Id` | `iced::widget::Id` |
| Scrollable Ops | `scrollable::snap_to` | `operation::snap_to` |
| Input Status | `text_input::Status::Focused` (unit) | `text_input::Status::Focused { is_hovered }` (struct) |
| Style Structs | N/A | Added `snap: bool` field to button/container::Style |
| Pixels Type | `u16` | `f32` for Pixels trait bounds |

### Files Modified (18 total)

**Core Application:**
- `Cargo.toml` - Version bump to iced 0.14.0
- `crates/rustirc-gui/src/app.rs` - Application API and rule widget
- `crates/rustirc-gui/src/dialogs.rs` - Space, checkbox, and max_width APIs
- `crates/rustirc-gui/src/material_demo.rs` - Application boot function

**Widgets:**
- `crates/rustirc-gui/src/widgets/message_view.rs` - Scrollable ID and operations
- `crates/rustirc-gui/src/widgets/user_list.rs` - Space widget
- `crates/rustirc-gui/src/widgets/tab_bar.rs` - Space widget
- `crates/rustirc-gui/src/widgets/status_bar.rs` - Space widget
- `crates/rustirc-gui/src/widgets/server_tree.rs` - Space widget
- `crates/rustirc-gui/src/widgets/input_area.rs` - Space widget

**Material Design 3 Components:**
- `crates/rustirc-gui/src/components/atoms/button.rs` - button::Style snap field
- `crates/rustirc-gui/src/components/atoms/input.rs` - text_input::Status pattern
- `crates/rustirc-gui/src/components/molecules/message_bubble.rs` - container::Style snap field
- `crates/rustirc-gui/src/components/molecules/search_bar.rs` - text_input::Status pattern
- `crates/rustirc-gui/src/components/organisms/responsive_layout.rs` - Space widget and Pixels type
- `crates/rustirc-gui/src/components/organisms/rich_text_editor.rs` - text_input::Status patterns

## Test plan

- [x] Build succeeds with zero compilation errors
- [x] Clippy passes with zero warnings (`cargo clippy -- -D warnings`)
- [x] All 131 tests pass (unit + doctests across all workspace crates)
- [ ] Manual testing: `cargo run` - GUI launches and functions correctly
- [ ] Manual testing: `cargo run -- --material-demo` - Material Design 3 demo works
- [ ] Manual testing: Basic IRC operations (connect, join channel, send messages)

## Quality Assurance

| Check | Status |
|-------|--------|
| Compilation | Zero errors |
| Clippy | Zero warnings |
| Tests | 131/131 passing |
| Formatting | cargo fmt clean |

## Migration Notes

This migration was performed systematically by:
1. Updating the iced version in workspace Cargo.toml
2. Running initial build to capture all 82+ compilation errors
3. Applying fixes in batches based on error categories
4. Verifying each fix with incremental builds
5. Running full quality assurance suite

The `snap: bool` field added to Style structs controls whether the widget snaps to pixel boundaries for crisp rendering.

---

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Major GUI framework upgrade with targeted refactors for Iced 0.14.0.
> 
> - Upgrade `iced` to `0.14.0`; switch to `iced::application(boot_fn, update, view).title(...)` in `app.rs` and `material_demo.rs`
> - Replace deprecated APIs across widgets/components:
>   - `Space::with_*`/`horizontal_space`/`vertical_space` → `Space::new().width/height(...)`
>   - `horizontal_rule` → `rule::horizontal`
>   - `checkbox(label, value)` → `checkbox(value).label(label)`
>   - `scrollable::Id` → `iced::widget::Id`; `scrollable::snap_to` → `operation::snap_to`
>   - `text_input::Status::Focused` (unit) → `Focused { .. }` pattern matching
> - Add required `snap: bool` to `button::Style` and `container::Style`; adjust Pixels trait usages from `u16` to `f32`
> - Touches core app, dialogs, material demo, and multiple widgets (`message_view`, `user_list`, `tab_bar`, `status_bar`, `server_tree`, `input_area`) to align with new APIs
> - QA: build clean, clippy clean, and all 131 tests passing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7c4dacf9dec56c08251dd0d3b9c2cf94fc6963a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->