### PR TITLE
fix(security): remediate 8 Dependabot advisories (rustls-webpki, rand, aws-lc-sys)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,9 +343,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -3186,7 +3186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3398,7 +3398,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -3454,18 +3454,18 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -3780,7 +3780,7 @@ dependencies = [
  "criterion",
  "dirs",
  "pretty_assertions",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustirc-protocol",
  "rustls",
  "rustls-pki-types",
@@ -3924,9 +3924,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/crates/rustirc-core/src/router.rs
+++ b/crates/rustirc-core/src/router.rs
@@ -545,21 +545,19 @@ impl MessageHandler for ChannelHandler {
                     }
                 }
             }
-            "TOPIC" => {
-                if message.params.len() >= 2 {
-                    let channel = &message.params[0];
-                    let topic = &message.params[1];
-                    info!("Topic changed in {}: {}", channel, topic);
+            "TOPIC" if message.params.len() >= 2 => {
+                let channel = &message.params[0];
+                let topic = &message.params[1];
+                info!("Topic changed in {}: {}", channel, topic);
 
-                    // Emit topic change event
-                    if let Some(event_bus) = self.get_event_bus(context).await {
-                        let event = Event::TopicChanged {
-                            connection_id: context.connection_id.clone(),
-                            channel: channel.clone(),
-                            topic: topic.clone(),
-                        };
-                        event_bus.emit(event).await;
-                    }
+                // Emit topic change event
+                if let Some(event_bus) = self.get_event_bus(context).await {
+                    let event = Event::TopicChanged {
+                        connection_id: context.connection_id.clone(),
+                        channel: channel.clone(),
+                        topic: topic.clone(),
+                    };
+                    event_bus.emit(event).await;
                 }
             }
             _ => {}


### PR DESCRIPTION
## Summary

Remediates **all 8 open Dependabot alerts** on `main` (3 high, 1 moderate, 4 low). All are transitive dependencies; the security fix is confined to `Cargo.lock` — no manifest constraint changes were needed (every bump is within the existing semver-compatible ranges).

A second, prerequisite commit fixes a pre-existing `clippy::collapsible_match` lint that current stable clippy (1.96.0, which CI pulls via `dtolnay/rust-toolchain@stable`) flags in `router.rs` — without it the CI clippy gate (`-D warnings`) would block this PR from going green. That fix is behavior-preserving (see below).

## Advisories resolved

| Package | From → To | Advisories | Severity |
|---------|-----------|-----------|----------|
| `rustls-webpki` | 0.103.9 → 0.103.13 | GHSA-82j2-j2ch-gfr8, GHSA-pwjx-qhcg-rvj4, GHSA-965h-392x-2mh5, GHSA-xgp8-3hg3-c2mh | high, medium, low, low |
| `aws-lc-sys` | 0.38.0 → 0.41.0 | GHSA-9f94-5g5w-gf6r, GHSA-394x-vwmw-crm3 | high, high |
| `rand` | 0.8.5 → 0.8.6 / 0.9.2 → 0.9.3 | GHSA-cq8v-f236-94qc (both major lines) | low |

`aws-lc-sys` 0.38 → patched line required bumping its parent `aws-lc-rs` 1.16.1 → 1.17.0 (the only change beyond the four target packages), since `aws-lc-rs 1.16.1` pinned `aws-lc-sys ^0.38` and excluded the patched 0.39+ line.

## Commits

1. `fix(core)` — hoist the TOPIC handler's `params.len() >= 2` check into a match guard (`"TOPIC" if … =>`). A short TOPIC message previously fell through the inner `if` as a no-op; it now fails the guard and falls through to the existing `_ => {}` arm — identical no-op, no behavior change.
2. `build(deps)` — the `Cargo.lock` advisory bumps above.

## Verification (local, rust 1.96.0)

- `cargo build --workspace`: 0 errors
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --workspace`: **266 passed** (18 suites)
- No old vulnerable versions remain in `Cargo.lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)